### PR TITLE
Swift 2.0

### DIFF
--- a/PeerKit.xcodeproj/project.pbxproj
+++ b/PeerKit.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1324B451B3D76C80081D767 /* libswiftMultipeerConnectivity.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1324B441B3D76C80081D767 /* libswiftMultipeerConnectivity.dylib */; };
+		A1324B481B3D77A90081D767 /* libswiftMultipeerConnectivity.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1324B471B3D77A90081D767 /* libswiftMultipeerConnectivity.dylib */; };
+		A1324B4A1B3D77C40081D767 /* libswiftMultipeerConnectivity.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1324B491B3D77C40081D767 /* libswiftMultipeerConnectivity.dylib */; };
 		E86EC4481AB734F5001A7734 /* PeerKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E89FD6C01A0C3CDC00C2FEF7 /* PeerKit.framework */; };
 		E86EC4581AB73597001A7734 /* PeerKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8DC82821AB7306C000BB585 /* PeerKit.framework */; };
 		E86EC45E1AB735A1001A7734 /* PeerKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89FD6D21A0C3CDC00C2FEF7 /* PeerKitTests.swift */; };
@@ -43,6 +46,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A1324B441B3D76C80081D767 /* libswiftMultipeerConnectivity.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libswiftMultipeerConnectivity.dylib; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/libswiftMultipeerConnectivity.dylib; sourceTree = DEVELOPER_DIR; };
+		A1324B471B3D77A90081D767 /* libswiftMultipeerConnectivity.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libswiftMultipeerConnectivity.dylib; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator/libswiftMultipeerConnectivity.dylib; sourceTree = DEVELOPER_DIR; };
+		A1324B491B3D77C40081D767 /* libswiftMultipeerConnectivity.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libswiftMultipeerConnectivity.dylib; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos/libswiftMultipeerConnectivity.dylib; sourceTree = DEVELOPER_DIR; };
 		E86EC4421AB734F5001A7734 /* PeerKit-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PeerKit-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E86EC4521AB73597001A7734 /* PeerKit-OSX-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PeerKit-OSX-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E89FD6C01A0C3CDC00C2FEF7 /* PeerKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PeerKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -63,6 +69,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1324B4A1B3D77C40081D767 /* libswiftMultipeerConnectivity.dylib in Frameworks */,
+				A1324B481B3D77A90081D767 /* libswiftMultipeerConnectivity.dylib in Frameworks */,
 				E86EC4481AB734F5001A7734 /* PeerKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -71,6 +79,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A1324B451B3D76C80081D767 /* libswiftMultipeerConnectivity.dylib in Frameworks */,
 				E86EC4581AB73597001A7734 /* PeerKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -92,11 +101,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A1324B461B3D77790081D767 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A1324B491B3D77C40081D767 /* libswiftMultipeerConnectivity.dylib */,
+				A1324B471B3D77A90081D767 /* libswiftMultipeerConnectivity.dylib */,
+				A1324B441B3D76C80081D767 /* libswiftMultipeerConnectivity.dylib */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		E89FD6B61A0C3CDC00C2FEF7 = {
 			isa = PBXGroup;
 			children = (
 				E89FD6C21A0C3CDC00C2FEF7 /* PeerKit */,
 				E89FD6CF1A0C3CDC00C2FEF7 /* PeerKitTests */,
+				A1324B461B3D77790081D767 /* Frameworks */,
 				E89FD6C11A0C3CDC00C2FEF7 /* Products */,
 			);
 			sourceTree = "<group>";

--- a/PeerKit.xcodeproj/project.pbxproj
+++ b/PeerKit.xcodeproj/project.pbxproj
@@ -251,7 +251,8 @@
 		E89FD6B71A0C3CDC00C2FEF7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "JP Simard";
 				TargetAttributes = {
 					E86EC4411AB734F5001A7734 = {
@@ -392,6 +393,7 @@
 				INFOPLIST_FILE = PeerKitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -409,6 +411,7 @@
 				INFOPLIST_FILE = PeerKitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -418,6 +421,7 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -430,6 +434,7 @@
 				INFOPLIST_FILE = PeerKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -441,6 +446,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -449,6 +455,7 @@
 				INFOPLIST_FILE = PeerKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -475,6 +482,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -551,6 +559,7 @@
 				INFOPLIST_FILE = PeerKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = PeerKit;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,6 +578,7 @@
 				INFOPLIST_FILE = PeerKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = PeerKit;
 				SKIP_INSTALL = YES;
 			};
@@ -594,6 +604,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = PeerKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -617,6 +628,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.jpsim.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = PeerKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/PeerKit.xcodeproj/xcshareddata/xcschemes/PeerKit-OSX.xcscheme
+++ b/PeerKit.xcodeproj/xcshareddata/xcschemes/PeerKit-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:PeerKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/PeerKit.xcodeproj/xcshareddata/xcschemes/PeerKit-iOS.xcscheme
+++ b/PeerKit.xcodeproj/xcshareddata/xcschemes/PeerKit-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:PeerKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/PeerKit/Advertiser.swift
+++ b/PeerKit/Advertiser.swift
@@ -20,7 +20,7 @@ class Advertiser: NSObject, MCNearbyServiceAdvertiserDelegate {
 
     private var advertiser: MCNearbyServiceAdvertiser?
 
-    func startAdvertising(#serviceType: String, discoveryInfo: [String: String]? = nil) {
+    func startAdvertising(serviceType serviceType: String, discoveryInfo: [String: String]? = nil) {
         advertiser = MCNearbyServiceAdvertiser(peer: mcSession.myPeerID, discoveryInfo: discoveryInfo, serviceType: serviceType)
         advertiser?.delegate = self
         advertiser?.startAdvertisingPeer()
@@ -31,7 +31,7 @@ class Advertiser: NSObject, MCNearbyServiceAdvertiserDelegate {
         advertiser?.stopAdvertisingPeer()
     }
 
-    func advertiser(advertiser: MCNearbyServiceAdvertiser!, didReceiveInvitationFromPeer peerID: MCPeerID!, withContext context: NSData?, invitationHandler: ((Bool, MCSession!) -> Void)!) {
+    func advertiser(advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: NSData?, invitationHandler: (Bool, MCSession) -> Void) {
         let accept = mcSession.myPeerID.hashValue > peerID.hashValue
         invitationHandler(accept, mcSession)
         if accept {

--- a/PeerKit/Advertiser.swift
+++ b/PeerKit/Advertiser.swift
@@ -9,6 +9,7 @@
 import Foundation
 import MultipeerConnectivity
 
+@available(OSXApplicationExtension 10.10, *)
 class Advertiser: NSObject, MCNearbyServiceAdvertiserDelegate {
 
     let mcSession: MCSession

--- a/PeerKit/Browser.swift
+++ b/PeerKit/Browser.swift
@@ -33,11 +33,11 @@ class Browser: NSObject, MCNearbyServiceBrowserDelegate {
         mcBrowser?.stopBrowsingForPeers()
     }
 
-    func browser(browser: MCNearbyServiceBrowser!, foundPeer peerID: MCPeerID!, withDiscoveryInfo info: [NSObject : AnyObject]!) {
+    func browser(browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
         browser.invitePeer(peerID, toSession: mcSession, withContext: nil, timeout: 30)
     }
 
-    func browser(browser: MCNearbyServiceBrowser!, lostPeer peerID: MCPeerID!) {
+    func browser(browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
         // unused
     }
 }

--- a/PeerKit/Browser.swift
+++ b/PeerKit/Browser.swift
@@ -11,6 +11,7 @@ import MultipeerConnectivity
 
 let timeStarted = NSDate()
 
+@available(OSXApplicationExtension 10.10, *)
 class Browser: NSObject, MCNearbyServiceBrowserDelegate {
 
     let mcSession: MCSession

--- a/PeerKit/Info.plist
+++ b/PeerKit/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.jpsim.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/PeerKit/PeerKit.swift
+++ b/PeerKit/PeerKit.swift
@@ -11,19 +11,30 @@ import MultipeerConnectivity
 
 // MARK: Type Aliases
 
+@available(OSXApplicationExtension 10.10, *)
 public typealias PeerBlock = ((myPeerID: MCPeerID, peerID: MCPeerID) -> Void)
+@available(OSXApplicationExtension 10.10, *)
 public typealias EventBlock = ((peerID: MCPeerID, event: String, object: AnyObject?) -> Void)
+@available(OSXApplicationExtension 10.10, *)
 public typealias ObjectBlock = ((peerID: MCPeerID, object: AnyObject?) -> Void)
+@available(OSXApplicationExtension 10.10, *)
 public typealias ResourceBlock = ((myPeerID: MCPeerID, resourceName: String, peer: MCPeerID, localURL: NSURL) -> Void)
 
 // MARK: Event Blocks
 
+@available(OSXApplicationExtension 10.10, *)
 public var onConnecting: PeerBlock?
+@available(OSXApplicationExtension 10.10, *)
 public var onConnect: PeerBlock?
+@available(OSXApplicationExtension 10.10, *)
 public var onDisconnect: PeerBlock?
+@available(OSXApplicationExtension 10.10, *)
 public var onEvent: EventBlock?
+@available(OSXApplicationExtension 10.10, *)
 public var onEventObject: ObjectBlock?
+@available(OSXApplicationExtension 10.10, *)
 public var onFinishReceivingResource: ResourceBlock?
+@available(OSXApplicationExtension 10.10, *)
 public var eventBlocks = [String: ObjectBlock]()
 
 // MARK: PeerKit Globals
@@ -35,11 +46,14 @@ public let myName = UIDevice.currentDevice().name
 public let myName = NSHost.currentHost().localizedName ?? ""
 #endif
 
+@available(OSXApplicationExtension 10.10, *)
 public var transceiver = Transceiver(displayName: myName)
+@available(OSXApplicationExtension 10.10, *)
 public var session: MCSession?
 
 // MARK: Event Handling
 
+@available(OSXApplicationExtension 10.10, *)
 func didConnecting(myPeerID: MCPeerID, peer: MCPeerID) {
     if let onConnecting = onConnecting {
         dispatch_async(dispatch_get_main_queue()) {
@@ -48,6 +62,7 @@ func didConnecting(myPeerID: MCPeerID, peer: MCPeerID) {
     }
 }
 
+@available(OSXApplicationExtension 10.10, *)
 func didConnect(myPeerID: MCPeerID, peer: MCPeerID) {
     if session == nil {
         session = transceiver.session.mcSession
@@ -59,6 +74,7 @@ func didConnect(myPeerID: MCPeerID, peer: MCPeerID) {
     }
 }
 
+@available(OSXApplicationExtension 10.10, *)
 func didDisconnect(myPeerID: MCPeerID, peer: MCPeerID) {
     if let onDisconnect = onDisconnect {
         dispatch_async(dispatch_get_main_queue()) {
@@ -67,6 +83,7 @@ func didDisconnect(myPeerID: MCPeerID, peer: MCPeerID) {
     }
 }
 
+@available(OSXApplicationExtension 10.10, *)
 func didReceiveData(data: NSData, fromPeer peer: MCPeerID) {
     if let dict = NSKeyedUnarchiver.unarchiveObjectWithData(data) as? [String: AnyObject],
         let event = dict["event"] as? String,
@@ -82,6 +99,7 @@ func didReceiveData(data: NSData, fromPeer peer: MCPeerID) {
     }
 }
 
+@available(OSXApplicationExtension 10.10, *)
 func didFinishReceivingResource(myPeerID: MCPeerID, resourceName: String, fromPeer peer: MCPeerID, atURL localURL: NSURL) {
     if let onFinishReceivingResource = onFinishReceivingResource {
         dispatch_async(dispatch_get_main_queue()) {
@@ -92,18 +110,22 @@ func didFinishReceivingResource(myPeerID: MCPeerID, resourceName: String, fromPe
 
 // MARK: Advertise/Browse
 
+@available(OSXApplicationExtension 10.10, *)
 public func transceive(serviceType: String, discoveryInfo: [String: String]? = nil) {
     transceiver.startTransceiving(serviceType: serviceType, discoveryInfo: discoveryInfo)
 }
 
+@available(OSXApplicationExtension 10.10, *)
 public func advertise(serviceType: String, discoveryInfo: [String: String]? = nil) {
     transceiver.startAdvertising(serviceType: serviceType, discoveryInfo: discoveryInfo)
 }
 
+@available(OSXApplicationExtension 10.10, *)
 public func browse(serviceType: String) {
     transceiver.startBrowsing(serviceType: serviceType)
 }
 
+@available(OSXApplicationExtension 10.10, *)
 public func stopTransceiving() {
     transceiver.stopTransceiving()
     session = nil
@@ -111,6 +133,7 @@ public func stopTransceiving() {
 
 // MARK: Events
 
+@available(OSXApplicationExtension 10.10, *)
 public func sendEvent(event: String, object: AnyObject? = nil, toPeers peers: [MCPeerID]? = session?.connectedPeers as [MCPeerID]?) {
     if peers == nil || (peers!.count == 0) {
         return
@@ -129,6 +152,7 @@ public func sendEvent(event: String, object: AnyObject? = nil, toPeers peers: [M
     }
 }
 
+@available(OSXApplicationExtension 10.10, *)
 public func sendResourceAtURL(resourceURL: NSURL!,
                    withName resourceName: String!,
   toPeers peers: [MCPeerID]? = session?.connectedPeers as [MCPeerID]?,

--- a/PeerKit/PeerKit.swift
+++ b/PeerKit/PeerKit.swift
@@ -111,7 +111,7 @@ public func stopTransceiving() {
 
 // MARK: Events
 
-public func sendEvent(event: String, object: AnyObject? = nil, toPeers peers: [MCPeerID]? = session?.connectedPeers as? [MCPeerID]) {
+public func sendEvent(event: String, object: AnyObject? = nil, toPeers peers: [MCPeerID]? = session?.connectedPeers as [MCPeerID]?) {
     if peers == nil || (peers!.count == 0) {
         return
     }
@@ -120,16 +120,22 @@ public func sendEvent(event: String, object: AnyObject? = nil, toPeers peers: [M
         rootObject["object"] = object
     }
     let data = NSKeyedArchiver.archivedDataWithRootObject(rootObject)
-    session?.sendData(data, toPeers: peers, withMode: .Reliable, error: nil)
+
+    if let peers = peers {
+        do {
+            try session?.sendData(data, toPeers: peers, withMode: .Reliable)
+        } catch _ {
+        }
+    }
 }
 
 public func sendResourceAtURL(resourceURL: NSURL!,
                    withName resourceName: String!,
-  toPeers peers: [MCPeerID]? = session?.connectedPeers as? [MCPeerID],
-  withCompletionHandler completionHandler: ((NSError!) -> Void)!) -> [NSProgress]! {
+  toPeers peers: [MCPeerID]? = session?.connectedPeers as [MCPeerID]?,
+  withCompletionHandler completionHandler: ((NSError!) -> Void)!) -> [NSProgress?]! {
 
-    if let session = session {
-        return peers?.map { peerID in
+    if let session = session, peers = peers {
+        return peers.map { peerID in
             return session.sendResourceAtURL(resourceURL, withName: resourceName, toPeer: peerID, withCompletionHandler: completionHandler)
         }
     }

--- a/PeerKit/Session.swift
+++ b/PeerKit/Session.swift
@@ -38,7 +38,7 @@ public class Session: NSObject, MCSessionDelegate {
 
     // MARK: MCSessionDelegate
 
-    public func session(session: MCSession!, peer peerID: MCPeerID!, didChangeState state: MCSessionState) {
+    public func session(session: MCSession, peer peerID: MCPeerID, didChangeState state: MCSessionState) {
         switch state {
             case .Connecting:
                 delegate?.connecting(myPeerID, toPeer: peerID)
@@ -49,21 +49,19 @@ public class Session: NSObject, MCSessionDelegate {
         }
     }
 
-    public func session(session: MCSession!, didReceiveData data: NSData!, fromPeer peerID: MCPeerID!) {
+    public func session(session: MCSession, didReceiveData data: NSData, fromPeer peerID: MCPeerID) {
         delegate?.receivedData(myPeerID, data: data, fromPeer: peerID)
     }
 
-    public func session(session: MCSession!, didReceiveStream stream: NSInputStream!, withName streamName: String!, fromPeer peerID: MCPeerID!) {
+    public func session(session: MCSession, didReceiveStream stream: NSInputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
         // unused
     }
 
-    public func session(session: MCSession!, didStartReceivingResourceWithName resourceName: String!, fromPeer peerID: MCPeerID!, withProgress progress: NSProgress!) {
+    public func session(session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, withProgress progress: NSProgress) {
         // unused
     }
 
-    public func session(session: MCSession!, didFinishReceivingResourceWithName resourceName: String!, fromPeer peerID: MCPeerID!, atURL localURL: NSURL!, withError error: NSError!) {
-        if (error == nil) {
-            delegate?.finishReceivingResource(myPeerID, resourceName: resourceName, fromPeer: peerID, atURL: localURL)
-        }
+    public func session(session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, atURL localURL: NSURL, withError error: NSError) {
+        delegate?.finishReceivingResource(myPeerID, resourceName: resourceName, fromPeer: peerID, atURL: localURL)
     }
 }

--- a/PeerKit/Session.swift
+++ b/PeerKit/Session.swift
@@ -9,6 +9,7 @@
 import Foundation
 import MultipeerConnectivity
 
+@available(OSXApplicationExtension 10.10, *)
 public protocol SessionDelegate {
     func connecting(myPeerID: MCPeerID, toPeer peer: MCPeerID)
     func connected(myPeerID: MCPeerID, toPeer peer: MCPeerID)
@@ -17,6 +18,7 @@ public protocol SessionDelegate {
     func finishReceivingResource(myPeerID: MCPeerID, resourceName: String, fromPeer peer: MCPeerID, atURL localURL: NSURL)
 }
 
+@available(OSXApplicationExtension 10.10, *)
 public class Session: NSObject, MCSessionDelegate {
     public private(set) var myPeerID: MCPeerID
     var delegate: SessionDelegate?

--- a/PeerKit/Transceiver.swift
+++ b/PeerKit/Transceiver.swift
@@ -27,7 +27,7 @@ public class Transceiver: SessionDelegate {
         session.delegate = self
     }
 
-    func startTransceiving(#serviceType: String, discoveryInfo: [String: String]? = nil) {
+    func startTransceiving(serviceType serviceType: String, discoveryInfo: [String: String]? = nil) {
         advertiser.startAdvertising(serviceType: serviceType, discoveryInfo: discoveryInfo)
         browser.startBrowsing(serviceType)
         transceiverMode = .Both
@@ -40,26 +40,26 @@ public class Transceiver: SessionDelegate {
         session.disconnect()
     }
 
-    func startAdvertising(#serviceType: String, discoveryInfo: [String: String]? = nil) {
+    func startAdvertising(serviceType serviceType: String, discoveryInfo: [String: String]? = nil) {
         advertiser.startAdvertising(serviceType: serviceType, discoveryInfo: discoveryInfo)
         transceiverMode = .Advertise
     }
 
-    func startBrowsing(#serviceType: String) {
+    func startBrowsing(serviceType serviceType: String) {
         browser.startBrowsing(serviceType)
         transceiverMode = .Browse
     }
 
     public func connecting(myPeerID: MCPeerID, toPeer peer: MCPeerID) {
-        didConnecting(myPeerID, peer)
+        didConnecting(myPeerID, peer: peer)
     }
 
     public func connected(myPeerID: MCPeerID, toPeer peer: MCPeerID) {
-        didConnect(myPeerID, peer)
+        didConnect(myPeerID, peer: peer)
     }
 
     public func disconnected(myPeerID: MCPeerID, fromPeer peer: MCPeerID) {
-        didDisconnect(myPeerID, peer)
+        didDisconnect(myPeerID, peer: peer)
     }
 
     public func receivedData(myPeerID: MCPeerID, data: NSData, fromPeer peer: MCPeerID) {
@@ -67,6 +67,6 @@ public class Transceiver: SessionDelegate {
     }
 
     public func finishReceivingResource(myPeerID: MCPeerID, resourceName: String, fromPeer peer: MCPeerID, atURL localURL: NSURL) {
-        didFinishReceivingResource(myPeerID, resourceName, fromPeer: peer, atURL: localURL)
+        didFinishReceivingResource(myPeerID, resourceName: resourceName, fromPeer: peer, atURL: localURL)
     }
 }

--- a/PeerKit/Transceiver.swift
+++ b/PeerKit/Transceiver.swift
@@ -13,6 +13,7 @@ enum TransceiverMode {
     case Browse, Advertise, Both
 }
 
+@available(OSXApplicationExtension 10.10, *)
 public class Transceiver: SessionDelegate {
 
     var transceiverMode = TransceiverMode.Both

--- a/PeerKitTests/Info.plist
+++ b/PeerKitTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.jpsim.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/PeerKitTests/PeerKitTests.swift
+++ b/PeerKitTests/PeerKitTests.swift
@@ -15,6 +15,6 @@ import PeerKit
 
 class PeerKitTests: XCTestCase {
     func testDeviceName() {
-        XCTAssert(count(myName) > 0, "Device name should be a non-empty string")
+        XCTAssert(myName.characters.count > 0, "Device name should be a non-empty string")
     }
 }


### PR DESCRIPTION
This migrates PeerKit to Swift 2.0 - it is slightly horrible, because of loads of @available attributes being required to work on OS X and also because @rpath for test bundles seems messed up in the betas.

You probably don't want this in master, but maybe it is a good idea to have either this PR open or a Swift 2 branch on the main repo?