### PR TITLE
Removed explicit value for String-based enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 PeerKit.transceive("com-jpsim-myApp")
 
 enum Event: String {
-    case StartGame = "StartGame", EndGame = "EndGame"
+    case StartGame, EndGame
 }
 
 // Send a StartGame event with attached data to all peers


### PR DESCRIPTION
Event.rawValue is generated automatically for each case, so it's not necessary to add the string values manually.