### PR TITLE
Accept all peer requests that did not originate from device

### DIFF
--- a/PeerKit/Advertiser.swift
+++ b/PeerKit/Advertiser.swift
@@ -38,7 +38,8 @@ class Advertiser: NSObject, MCNearbyServiceAdvertiserDelegate {
 //    }
 
     func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-        invitationHandler(true, mcSession)
+        let accept = mcSession.myPeerID.displayName.hashValue != peerID.displayName.hashValue
+        invitationHandler(accept, mcSession)
         if accept {
             stopAdvertising()
         }

--- a/PeerKit/Advertiser.swift
+++ b/PeerKit/Advertiser.swift
@@ -38,8 +38,7 @@ class Advertiser: NSObject, MCNearbyServiceAdvertiserDelegate {
 //    }
 
     func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-        let accept = mcSession.myPeerID.hashValue > peerID.hashValue
-        invitationHandler(accept, mcSession)
+        invitationHandler(true, mcSession)
         if accept {
             stopAdvertising()
         }


### PR DESCRIPTION
`myPeerID.hashValue` not guaranteed to be greater than `peerID.hashValue`. Accept all requests that don't originate from current device.